### PR TITLE
Player messaging fixes

### DIFF
--- a/Data/Scripts/GardenConquest/Messaging/ResponseProcessor.cs
+++ b/Data/Scripts/GardenConquest/Messaging/ResponseProcessor.cs
@@ -73,7 +73,8 @@ namespace GardenConquest.Messaging {
 					if (fac == null || !msg.Destination.Contains(fac.FactionId))
 						return; // Message not meant for us
 				} else if (msg.DestType == BaseResponse.DEST_TYPE.PLAYER) {
-					if (!msg.Destination.Contains(MyAPIGateway.Session.Player.PlayerID))
+					long localUserId = (long)MyAPIGateway.Session.Player.SteamUserId;
+					if (!msg.Destination.Contains(localUserId))
 						return; // Message not meant for us
 				}
 


### PR DESCRIPTION
This fixes player messaging issue #44.

There are a couple fixes to accomplish this:

First, the message type used to send player notifications in Core was set to Faction - changed that. 

Next, the response processor would always error on an uninitialized object error because the result from `getPlayersNearGrid` was always an empty list. I fixed this by setting a specific check for that condition in the response processor and by rewriting `getPlayersNearGrid`. 

The problem with `getPlayersNearGrid` was we were looking for `IMyPlayer`s near the grid, when we were actually working with entities so `IMyCharacter` is what we would find. However, even if we isolated IMyCharacters, it seems very difficult to get at their associated IMyPlayer. Furthermore we had to do a sphere test and deal with a bunch of entities - it turns out the game returned one entity for every nearby block.

Turns out ModAPI provides `Players.GetPlayers()`, and the players have a `GetPosition()` method, so from there it was a very simple process to determine if they were close enough. I benchmarked the two approaches and this is definitely faster - at 1000x the old method took 22ms while this was still at ~0.

Finally, I changed the passed IDs for notification destinations to use `SteamUserId` instead of `PlayerID`. From the comments in SE core, I'm gathering that `PlayerID` corresponds to a particular control location for a player and is deprecated in favor of SteamUserId, might be related to their recent X-Box work.
