### PR TITLE
Small fixes

### DIFF
--- a/Data/Components.sbc
+++ b/Data/Components.sbc
@@ -13,8 +13,8 @@
         <Y>0.5</Y>
         <Z>0.4</Z>
       </Size>
-      <Mass>8</Mass>
-      <Volume>140</Volume>
+      <Mass>2</Mass>
+      <Volume>2</Volume>
       <Model>Models\Components\radio_communication_components_component.mwm</Model>
       <MaxIntegrity>1</MaxIntegrity>
       <DropProbability>0.1</DropProbability>

--- a/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
+++ b/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
@@ -570,9 +570,10 @@ namespace GardenConquest.Blocks {
 					//log("incrementing type count " + m_BlockTypeCounts[typeID], "updateBlockCountsWith");
 					m_BlockTypeCounts[typeID] = m_BlockTypeCounts[typeID] + 1;
 					int count = m_BlockTypeCounts[typeID];
+					int limit = m_EffectiveRules.BlockTypeLimits[typeID];
 					log(type.DisplayName + " count now: " + count, "updateBlockCountsWith");
 
-					if (count > m_EffectiveRules.BlockTypeLimits[typeID])
+					if (count > limit && limit >= 0)
 						violated_types.Add(type);
 				}
 			}
@@ -950,7 +951,7 @@ namespace GardenConquest.Blocks {
 				int count = counts[typeID];
 				int limit = limits[typeID];
 
-				if (count > limit) {
+				if (count > limit && limit >= 0) {
 					violations.Add(new VIOLATION() {
 						Type = VIOLATION_TYPE.BLOCK_TYPE,
 						BlockType = type,

--- a/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
+++ b/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
@@ -36,7 +36,8 @@ namespace GardenConquest.Core {
 			"        cps            - Control Points\n" +
 			"        licenses    - Ship License components\n" +
 			"/gc fleet - Information on your faction's fleet \n" +
-			"/gc fleet remove \"Ship Name\"- Disown a ship";
+			//"/gc fleet remove \"Ship Name\"- Disown a ship";
+			"/gc violations - Your fleet's current rule violations, if any";
 
 		private static string s_HelpClassText =
 			"Classes:\n\n" +


### PR DESCRIPTION
- Fixed negative block limits being applied as zero instead of unlimited
- Removed `/fleet disown` from commands in `/gc help` until working
- Added `/violations` to commands in `/gc help`
- Lowered ship license mass and volume to equal that of explosives and scrap metal based on feedback from players, but we can discuss
