### PR TITLE
Rewrote /gc fleet and now shows grid coordinates

### DIFF
--- a/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
+++ b/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
@@ -32,6 +32,15 @@ namespace GardenConquest.Blocks {
 	public class GridEnforcer : MyGameLogicComponent {
 
 		#region Structs and Enums
+		public struct GridData {
+			public bool supported { get; set; }
+			public long shipID { get; set; }
+			public HullClass.CLASS shipClass { get; set; }
+			public string shipName { get; set; }
+			public int blockCount { get; set; }
+			public bool displayPos { get; set; }
+			public VRageMath.Vector3D shipPosition { get; set; }
+		}
 
 		public enum VIOLATION_TYPE {
 			NONE,
@@ -1451,6 +1460,47 @@ namespace GardenConquest.Blocks {
 		private void log(String message, String method = null, Logger.severity level = Logger.severity.DEBUG) {
 			if (m_Logger != null)
 				m_Logger.log(level, method, message);
+		}
+
+		public void serialize(VRage.ByteStream stream) {
+			stream.addBoolean(SupportedByFleet);
+			stream.addLong(Grid.EntityId);
+			stream.addUShort((ushort)m_EffectiveClass);
+			stream.addString(Grid.DisplayName);
+			stream.addUShort((ushort)BlockCount);
+
+			// Serialize position data if the owner of the grid
+			if (Grid.canDisplayPositionTo(Owner.PlayerID)) {
+				stream.addBoolean(true);
+				stream.addLong((long)Grid.GetPosition().X);
+				stream.addLong((long)Grid.GetPosition().Y);
+				stream.addLong((long)Grid.GetPosition().Z);
+			}
+			else {
+				stream.addBoolean(false);
+			}
+		}
+
+		public static GridData deserialize(VRage.ByteStream stream) {
+			GridData result = new GridData();
+
+			result.supported = stream.getBoolean();
+			result.shipID = stream.getLong();
+			result.shipClass = (HullClass.CLASS)stream.getUShort();
+			result.shipName = stream.getString();
+			result.blockCount = (int)stream.getUShort();
+			result.displayPos = stream.getBoolean();
+			if (result.displayPos) {
+				long x, y, z;
+				x = stream.getLong();
+				y = stream.getLong();
+				z = stream.getLong();
+				result.shipPosition = new VRageMath.Vector3D(x, y, z);
+			}
+			else {
+				result.shipPosition = new VRageMath.Vector3D();
+			}
+			return result;
 		}
 
 		#endregion

--- a/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
+++ b/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
@@ -117,10 +117,10 @@ namespace GardenConquest.Core {
 							} else {
 								switch (cmd[2].ToLower()) {
 									case "disown":
-										String entityID = "";
-										if (numCommands > 2)
-											entityID = cmd[3];
-										//m_MailMan.requestDisown(cmd[3]);
+										// Disabled until the Mod API supports the ability to change owners of individual blocks
+										/*if (numCommands == 4) {
+											m_MailMan.requestDisown(cmd[3], cmd[4]);
+										}*/
 										break;
 								}
 							}

--- a/Data/Scripts/GardenConquest/Extensions/ByteConverterExtension.cs
+++ b/Data/Scripts/GardenConquest/Extensions/ByteConverterExtension.cs
@@ -66,6 +66,14 @@ namespace GardenConquest.Extensions {
 			return new string(cstr);
 		}
 
+		public static void addBoolean(this VRage.ByteStream stream, bool b) {
+			stream.WriteByte(Convert.ToByte(b));
+		}
+
+		public static bool getBoolean(this VRage.ByteStream stream) {
+			return Convert.ToBoolean(stream.ReadByte());
+		}
+
 		public static void addLongList(this VRage.ByteStream stream, List<long> L) {
 			if (L == null) {
 				stream.addUShort(0);

--- a/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
+++ b/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
@@ -85,6 +85,54 @@ namespace GardenConquest.Extensions {
 			return true;
 		}
 
+		/// <summary>
+		/// Is the given player allowed to see the given grid's position?
+		/// Player is able to see the position of the grid if the player
+		/// is part of the mainCockpit's faction OR the player owns the mainCockpit
+		/// </summary>
+		/// <param name="playerID"></param>
+		/// <param name="grid"></param>
+		/// <remarks>
+		/// Relatively expensive since we iterate through all blocks in grid!
+		/// </remarks>
+		/// <returns></returns>
+		public static bool canDisplayPositionTo(this IMyCubeGrid grid, long playerID) {
+			bool result = false;
+			List<IMySlimBlock> fatBlocks = new List<IMySlimBlock>();
+
+			// Get only FatBlocks from the blocks list from the grid
+			Func<IMySlimBlock, bool> isFatBlock = b => b.FatBlock != null;
+			grid.GetBlocks(fatBlocks, isFatBlock);
+
+			// We'll need the faction list to compare the factions of the given player and the owners of the fatblocks in the grid
+			IMyFactionCollection factions = MyAPIGateway.Session.Factions;
+
+			// Go through and search for the main cockpit. If found, set result and break out of loop, since there should only be 1 main cockpit
+			foreach (IMySlimBlock block in fatBlocks) {
+				if (block.FatBlock is InGame.IMyShipController) {
+					if (Interfaces.TerminalPropertyExtensions.GetValueBool(block.FatBlock as InGame.IMyTerminalBlock, "MainCockpit")) {
+						IMyFaction blocksFaction = factions.TryGetPlayerFaction(block.FatBlock.OwnerId);
+						// Owner of block is running solo
+						if (blocksFaction == null) {
+							if (block.FatBlock.OwnerId == playerID) {
+								result = true;
+								break;
+							}
+						}
+						// Owner of block is part of a faction
+						else {
+							long owningFactionID = blocksFaction.FactionId;
+							if (owningFactionID == factions.TryGetPlayerFaction(playerID).FactionId) {
+								result = true;
+								break;
+							}
+						}
+					}
+				}
+			}
+			return result;
+		}
+
 	}
 
 }

--- a/Data/Scripts/GardenConquest/Messaging/BaseRequest.cs
+++ b/Data/Scripts/GardenConquest/Messaging/BaseRequest.cs
@@ -15,7 +15,8 @@ namespace GardenConquest.Messaging {
 		public enum TYPE {
 			FLEET,
 			VIOLATIONS,
-			SETTINGS
+			SETTINGS,
+			DISOWN
 		}
 
 		public TYPE MsgType { get; set; }
@@ -55,6 +56,9 @@ namespace GardenConquest.Messaging {
 					break;
 				case TYPE.VIOLATIONS:
 					msg = new ViolationsRequest();
+					break;
+				case TYPE.DISOWN:
+					msg = new DisownRequest();
 					break;
 			}
 

--- a/Data/Scripts/GardenConquest/Messaging/BaseResponse.cs
+++ b/Data/Scripts/GardenConquest/Messaging/BaseResponse.cs
@@ -17,7 +17,8 @@ namespace GardenConquest.Messaging {
 		public enum TYPE {
 			NOTIFICATION,
 			DIALOG,
-			SETTINGS
+			SETTINGS,
+			FLEET
 		}
 
 		/// <summary>
@@ -72,6 +73,9 @@ namespace GardenConquest.Messaging {
 					break;
 				case TYPE.SETTINGS:
 					msg = new SettingsResponse();
+					break;
+				case TYPE.FLEET:
+					msg = new FleetResponse();
 					break;
 			}
 

--- a/Data/Scripts/GardenConquest/Messaging/DisownRequest.cs
+++ b/Data/Scripts/GardenConquest/Messaging/DisownRequest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GardenConquest.Extensions;
+
+namespace GardenConquest.Messaging {
+
+	/// <summary>
+	/// Requests server to disown a client's grid
+	/// </summary>
+	public class DisownRequest : BaseRequest {
+		private const int BaseSize = HeaderSize;
+
+		public long EntityID;
+
+		public DisownRequest()
+			: base(BaseRequest.TYPE.DISOWN) {
+
+		}
+
+		public override byte[] serialize() {
+			VRage.ByteStream bs = new VRage.ByteStream(BaseSize, true);
+
+			byte[] bMessage = base.serialize();
+			bs.Write(bMessage, 0, bMessage.Length);
+
+			bs.addLong(EntityID);
+
+			return bs.Data;
+		}
+
+		public override void deserialize(VRage.ByteStream stream) {
+			base.deserialize(stream);
+
+			EntityID = stream.getLong();
+		}
+	}
+}

--- a/Data/Scripts/GardenConquest/Messaging/FleetResponse.cs
+++ b/Data/Scripts/GardenConquest/Messaging/FleetResponse.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GardenConquest.Blocks;
+using GardenConquest.Extensions;
+using GardenConquest.Records;
+
+namespace GardenConquest.Messaging {
+	public class FleetResponse : BaseResponse {
+
+		public FactionFleet Fleet;
+		public GridOwner.OWNER Owner;
+		public List<GridEnforcer.GridData> FleetData;
+		public GridOwner.OWNER_TYPE OwnerType;
+
+		private const int BaseSize = HeaderSize;
+
+		public FleetResponse()
+			: base(BaseResponse.TYPE.FLEET) {
+
+		}
+
+		public override byte[] serialize() {
+			VRage.ByteStream bs = new VRage.ByteStream(BaseSize, true);
+
+			byte[] bmessage = base.serialize();
+			bs.Write(bmessage, 0, bmessage.Length);
+
+			bs.addUShort((ushort)Owner.OwnerType);
+			Fleet.serialize(bs);
+
+			return bs.Data;
+		}
+
+		public override void deserialize(VRage.ByteStream stream) {
+			base.deserialize(stream);
+			OwnerType = (GridOwner.OWNER_TYPE)stream.getUShort();
+			FleetData = new List<GridEnforcer.GridData>(FactionFleet.deserialize(stream));
+		}
+
+
+	}
+}

--- a/Data/Scripts/GardenConquest/Records/FactionFleet.cs
+++ b/Data/Scripts/GardenConquest/Records/FactionFleet.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 using GardenConquest.Blocks;
+using GardenConquest.Extensions;
 using GardenConquest.Core;
 
 namespace GardenConquest.Records {
@@ -346,6 +347,34 @@ namespace GardenConquest.Records {
 					}
 					result += "\n";
 				}
+			}
+			return result;
+		}
+
+		public void serialize(VRage.ByteStream stream) {
+			stream.addUShort((ushort)TotalCount);
+			for (int i = 0; i < m_Counts.Length; ++i) {
+				if (m_Counts[i] > 0) {
+					if (m_SupportedGrids[i].Count > 0) {
+						foreach (KeyValuePair<long, GridEnforcer> entry in m_SupportedGrids[i])
+							entry.Value.serialize(stream);
+					}
+					if (m_UnsupportedGrids[i].Count > 0) {
+						foreach (KeyValuePair<long, GridEnforcer> entry in m_UnsupportedGrids[i])
+							entry.Value.serialize(stream);
+					}
+				}
+			}
+		}
+
+		public static List<GridEnforcer.GridData> deserialize(VRage.ByteStream stream) {
+			List<GridEnforcer.GridData> result = new List<GridEnforcer.GridData>();
+
+			ushort count = stream.getUShort();
+
+			for (int i = 0; i < count; ++i) {
+				GridEnforcer.GridData incomingData = GridEnforcer.deserialize(stream);
+				result.Add(incomingData);
 			}
 			return result;
 		}

--- a/Data/Scripts/GardenConquest/Records/HullRuleSet.cs
+++ b/Data/Scripts/GardenConquest/Records/HullRuleSet.cs
@@ -42,6 +42,7 @@ namespace GardenConquest.Records {
 			stream.addUShort((ushort)MaxPerSoloPlayer);
 			stream.addUShort((ushort)CaptureMultiplier);
 			stream.addLong(MaxBlocks);
+			stream.addBoolean(ShouldBeStation);
 
 			stream.addUShort((ushort)BlockTypeLimits.Length);
 			foreach (int limit in BlockTypeLimits) {
@@ -57,6 +58,7 @@ namespace GardenConquest.Records {
 			result.MaxPerSoloPlayer = stream.getUShort();
 			result.CaptureMultiplier = stream.getUShort();
 			result.MaxBlocks = (int)stream.getLong();
+			result.ShouldBeStation = stream.getBoolean();
 
 			ushort blockTypeLimitsCount = stream.getUShort();
 			result.BlockTypeLimits = new int[blockTypeLimitsCount];


### PR DESCRIPTION
/gc fleet is rewritten to send data to client now instead of just a dialog, which should allow for the implementation of /gc fleet disown. The problem right now with disown is that the current ModAPI doesn't have a changeOwner() method to change the owner of a block, so we can't really disown a player's grid. I've looked through the Space Engineers' source code and mostly figured out what method to expose so I'll throw up a PR on that and see if we can get that changeOwner() functionality.

Regardless, I've included most of the code for /gc fleet disown. Just need to uncomment a few lines when ModAPI supports block.changeOwner().

As for how /gc fleet is rewritten: instead of sending a dialog, the server now sends the client data about their fleet and the client stores it. The client will then build a string and call a dialog to display their fleet information. FleetResponse handles the serialization; it works pretty much the same as SettingsResponse. The data that's being sent can be found in the struct GridData in GridEnforcer.

/gc fleet also shows the player their grid coordinates, given that the player is the owner of the main cockpit OR the owner of the main cockpit is part of the player's faction. If the grid doesn't have a main cockpit, the coordinates won't show up.

Let me know if you want anything changed.
