### PR TITLE
Added /gc fleet stop and made small changes

### DIFF
--- a/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
+++ b/Data/Scripts/GardenConquest/Blocks/GridEnforcer.cs
@@ -1470,7 +1470,7 @@ namespace GardenConquest.Blocks {
 			stream.addUShort((ushort)BlockCount);
 
 			// Serialize position data if the owner of the grid
-			if (Grid.canDisplayPositionTo(Owner.PlayerID)) {
+			if (Grid.canInteractWith(Owner.PlayerID)) {
 				stream.addBoolean(true);
 				stream.addLong((long)Grid.GetPosition().X);
 				stream.addLong((long)Grid.GetPosition().Y);

--- a/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
+++ b/Data/Scripts/GardenConquest/Core/CommandProcessor.cs
@@ -37,6 +37,8 @@ namespace GardenConquest.Core {
 			"        cps            - Control Points\n" +
 			"        licenses    - Ship License components\n" +
 			"/gc fleet - Information on your fleet \n" +
+			"/gc fleet [command] - Commands for your fleet\n" +
+			"        stop [class] [id] - Stops your ship, given class and ID\n" +
 			//"/gc fleet remove \"Ship Name\"- Disown a ship";
 			"/gc violations - Your fleet's current rule violations, if any";
 
@@ -121,6 +123,11 @@ namespace GardenConquest.Core {
 										/*if (numCommands == 4) {
 											m_MailMan.requestDisown(cmd[3], cmd[4]);
 										}*/
+										break;
+									case "stop":
+										if (numCommands == 4) {
+											m_MailMan.requestStopGrid(cmd[3], cmd[4]);
+										}
 										break;
 								}
 							}

--- a/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
+++ b/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
@@ -97,7 +97,6 @@ namespace GardenConquest.Extensions {
 		/// </remarks>
 		/// <returns></returns>
 		public static bool canInteractWith(this IMyCubeGrid grid, long playerID) {
-			bool result = false;
 			List<IMySlimBlock> fatBlocks = new List<IMySlimBlock>();
 
 			// Get all cockpit blocks
@@ -107,28 +106,26 @@ namespace GardenConquest.Extensions {
 			// We'll need the faction list to compare the factions of the given player and the owners of the fatblocks in the grid
 			IMyFactionCollection factions = MyAPIGateway.Session.Factions;
 
-			// Go through and search for the main cockpit. If found, set result and break out of loop, since there should only be 1 main cockpit
+			// Go through and search for the main cockpit. If found, set return true
 			foreach (IMySlimBlock block in fatBlocks) {
 				if (Interfaces.TerminalPropertyExtensions.GetValueBool(block.FatBlock as InGame.IMyTerminalBlock, "MainCockpit")) {
 					IMyFaction blocksFaction = factions.TryGetPlayerFaction(block.FatBlock.OwnerId);
 					// Owner of block is running solo
 					if (blocksFaction == null) {
 						if (block.FatBlock.OwnerId == playerID) {
-							result = true;
-							break;
+							return true;
 						}
 					}
 					// Owner of block is part of a faction
 					else {
 						long owningFactionID = blocksFaction.FactionId;
 						if (owningFactionID == factions.TryGetPlayerFaction(playerID).FactionId) {
-							result = true;
-							break;
+							return true;
 						}
 					}
 				}
 			}
-			return result;
+			return false;
 		}
 
 	}

--- a/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
+++ b/Data/Scripts/GardenConquest/Extensions/GridExtensions.cs
@@ -86,9 +86,9 @@ namespace GardenConquest.Extensions {
 		}
 
 		/// <summary>
-		/// Is the given player allowed to see the given grid's position?
-		/// Player is able to see the position of the grid if the player
-		/// is part of the mainCockpit's faction OR the player owns the mainCockpit
+		/// Is the given player allowed get information or use commands on the grid?
+		/// Player is able to interact with the grid if the player is part of the
+		/// mainCockpit's faction OR the player owns the mainCockpit
 		/// </summary>
 		/// <param name="playerID"></param>
 		/// <param name="grid"></param>
@@ -96,12 +96,12 @@ namespace GardenConquest.Extensions {
 		/// Relatively expensive since we iterate through all blocks in grid!
 		/// </remarks>
 		/// <returns></returns>
-		public static bool canDisplayPositionTo(this IMyCubeGrid grid, long playerID) {
+		public static bool canInteractWith(this IMyCubeGrid grid, long playerID) {
 			bool result = false;
 			List<IMySlimBlock> fatBlocks = new List<IMySlimBlock>();
 
-			// Get only FatBlocks from the blocks list from the grid
-			Func<IMySlimBlock, bool> isFatBlock = b => b.FatBlock != null;
+			// Get all cockpit blocks
+			Func<IMySlimBlock, bool> isFatBlock = b => b.FatBlock != null && b.FatBlock is InGame.IMyShipController;
 			grid.GetBlocks(fatBlocks, isFatBlock);
 
 			// We'll need the faction list to compare the factions of the given player and the owners of the fatblocks in the grid
@@ -109,23 +109,21 @@ namespace GardenConquest.Extensions {
 
 			// Go through and search for the main cockpit. If found, set result and break out of loop, since there should only be 1 main cockpit
 			foreach (IMySlimBlock block in fatBlocks) {
-				if (block.FatBlock is InGame.IMyShipController) {
-					if (Interfaces.TerminalPropertyExtensions.GetValueBool(block.FatBlock as InGame.IMyTerminalBlock, "MainCockpit")) {
-						IMyFaction blocksFaction = factions.TryGetPlayerFaction(block.FatBlock.OwnerId);
-						// Owner of block is running solo
-						if (blocksFaction == null) {
-							if (block.FatBlock.OwnerId == playerID) {
-								result = true;
-								break;
-							}
+				if (Interfaces.TerminalPropertyExtensions.GetValueBool(block.FatBlock as InGame.IMyTerminalBlock, "MainCockpit")) {
+					IMyFaction blocksFaction = factions.TryGetPlayerFaction(block.FatBlock.OwnerId);
+					// Owner of block is running solo
+					if (blocksFaction == null) {
+						if (block.FatBlock.OwnerId == playerID) {
+							result = true;
+							break;
 						}
-						// Owner of block is part of a faction
-						else {
-							long owningFactionID = blocksFaction.FactionId;
-							if (owningFactionID == factions.TryGetPlayerFaction(playerID).FactionId) {
-								result = true;
-								break;
-							}
+					}
+					// Owner of block is part of a faction
+					else {
+						long owningFactionID = blocksFaction.FactionId;
+						if (owningFactionID == factions.TryGetPlayerFaction(playerID).FactionId) {
+							result = true;
+							break;
 						}
 					}
 				}

--- a/Data/Scripts/GardenConquest/GardenConquest.csproj
+++ b/Data/Scripts/GardenConquest/GardenConquest.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Messaging\SettingsRequest.cs" />
     <Compile Include="Messaging\SettingsResponse.cs" />
     <Compile Include="Messaging\NotificationResponse.cs" />
+    <Compile Include="Messaging\StopGridRequest.cs" />
     <Compile Include="Messaging\ViolationsRequest .cs" />
     <Compile Include="Messaging\FleetRequest.cs" />
     <Compile Include="Messaging\DialogResponse.cs" />

--- a/Data/Scripts/GardenConquest/Messaging/BaseRequest.cs
+++ b/Data/Scripts/GardenConquest/Messaging/BaseRequest.cs
@@ -16,7 +16,8 @@ namespace GardenConquest.Messaging {
 			FLEET,
 			VIOLATIONS,
 			SETTINGS,
-			DISOWN
+			DISOWN,
+			STOPGRID
 		}
 
 		public TYPE MsgType { get; set; }
@@ -59,6 +60,9 @@ namespace GardenConquest.Messaging {
 					break;
 				case TYPE.DISOWN:
 					msg = new DisownRequest();
+					break;
+				case TYPE.STOPGRID:
+					msg = new StopGridRequest();
 					break;
 			}
 

--- a/Data/Scripts/GardenConquest/Messaging/StopGridRequest.cs
+++ b/Data/Scripts/GardenConquest/Messaging/StopGridRequest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using GardenConquest.Extensions;
+
+namespace GardenConquest.Messaging {
+	public class StopGridRequest : BaseRequest {
+		private const int BaseSize = HeaderSize;
+
+		public long EntityID;
+
+		public StopGridRequest()
+			: base(BaseRequest.TYPE.STOPGRID) {
+
+		}
+
+		public override byte[] serialize() {
+			VRage.ByteStream bs = new VRage.ByteStream(BaseSize, true);
+
+			byte[] bMessage = base.serialize();
+			bs.Write(bMessage, 0, bMessage.Length);
+
+			bs.addLong(EntityID);
+
+			return bs.Data;
+		}
+
+		public override void deserialize(VRage.ByteStream stream) {
+			base.deserialize(stream);
+
+			EntityID = stream.getLong();
+		}
+	}
+}


### PR DESCRIPTION
Players can stop their ships by typing '/gc fleet stop [class] [id]', where class is the ShipClass and ID is the index given by '/gc fleet'.

Now noobs like me can stop our runaway ships instead of watching it fly away into oblivion when we accidently press T.
